### PR TITLE
Add data.js config, link classes, and fix carousel z-index bug

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,11 +18,33 @@ To publish changes, merge or push to `gh-pages`.
 All content lives in `index.html`. Sections: `#projects`, `#talks`, `#contact` (plus `#carousel` in the hero).
 
 - `css/resume.css` — custom styles (the only stylesheet to edit)
-- `js/main.js` — vanilla JS: photo carousel only (auto-advance, prev/next, dots, pause-on-hover)
+- `js/data.js` — single source of truth for personal info (name, email, institution, social links); edit this to update repeated values across the page
+- `js/main.js` — vanilla JS: config fill + photo carousel (auto-advance, prev/next, dots, pause-on-hover)
 - `fonts/` — self-hosted woff2 files (Instrument Serif, Space Grotesk — the only two active fonts)
 - `inputs/` — source assets: LaTeX CV (`main.tex`), design mockup (`mockup.html`), raw images
 
-No build tooling — edits are made directly to `css/resume.css` and `index.html`.
+No build tooling — edits are made directly to `css/resume.css`, `js/data.js`, and `index.html`.
+
+## Link conventions
+
+External links that should open in a new tab get a semantic class instead of inline `target`/`rel` attributes — JS applies those automatically at page load:
+
+- `.project-link` — links inside project cards
+- `.side-link` — links in the hero sidebar and JS-rendered blocks (institution, social links)
+- `.talk-link` — links in the teaching and PhD supervision lists
+
+Contact section links are rendered entirely from `js/data.js`; their `target`/`rel` are set in the JS template. The mailto link intentionally has no `target`.
+
+## `js/data.js` — personal info config
+
+To update a name, URL, or social handle, edit only `js/data.js`. The following are rendered from it at runtime (the HTML elements are empty placeholders):
+
+- `SITE.name` → nav, hero `<h1>`, footer
+- `SITE.institution.{lab,cnrs,footer}` → hero Institution block, footer text
+- `SITE.links` → hero Links block, contact section social rows
+- `SITE.email` → contact section email row
+
+`<head>` meta tags and JSON-LD structured data remain static in `index.html` (they are read before JS runs).
 
 ## Design
 

--- a/css/resume.css
+++ b/css/resume.css
@@ -321,6 +321,7 @@ nav {
 
 .carousel-btn {
   position: absolute;
+  z-index: 3;
   top: 50%;
   transform: translateY(-50%);
   width: 36px;

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
     <div class="topbar" aria-hidden="true"></div>
 
     <nav aria-label="Site navigation">
-      <span class="nav-name">Alexandre Boucaud</span>
+      <span class="nav-name" data-fill="name"></span>
       <ul class="nav-links" role="list">
         <li><a href="#projects">Projects</a></li>
         <li><a href="#talks">Teaching</a></li>
@@ -57,7 +57,7 @@
 
     <div class="hero">
       <div class="hero-main">
-        <h1 class="hero-title">Alexandre Boucaud</h1>
+        <h1 class="hero-title" data-fill="name"></h1>
         <p class="hero-eyebrow"><strong>Astronomer · Computational Engineer</strong></p>
         <p class="hero-bio">
           I build open-source software and pipelines for large-scale astronomical experiments, at the intersection of
@@ -70,24 +70,21 @@
       <div class="hero-side">
         <div class="side-block">
           <p class="side-key">Institution</p>
-          <p class="side-val">
-            <a href="https://apc.u-paris.fr" target="_blank" rel="noopener noreferrer">AstroParticule &amp; Cosmologie</a> · 
-            <a href="https://www.in2p3.cnrs.fr" target="_blank" rel="noopener noreferrer">CNRS/IN2P3</a>
-          </p>
+          <p class="side-val" data-render="institution"></p>
         </div>
         <div class="side-block">
           <p class="side-key">Research teams</p>
           <p class="side-val">
-            <a href="https://lightconeresearch.org/" target="_blank" rel="noopener noreferrer">Lightcone Research</a> ·
-            <a href="https://astrodeep.net/" target="_blank" rel="noopener noreferrer">AstroDeep</a>
+            <a class="side-link" href="https://lightconeresearch.org/">Lightcone Research</a> ·
+            <a class="side-link" href="https://astrodeep.net/">AstroDeep</a>
           </p>
         </div>
         <div class="side-block">
           <p class="side-key">Experiments</p>
           <p class="side-val">
-            <a href="https://rubinobservatory.org/" target="_blank" rel="noopener noreferrer">Vera Rubin Observatory</a> /
-            <a href="https://www.lsst.org/" target="_blank" rel="noopener noreferrer">LSST</a> ·
-            <a href="https://www.euclid-ec.org/" target="_blank" rel="noopener noreferrer">Euclid</a>
+            <a class="side-link" href="https://rubinobservatory.org/">Vera Rubin Observatory</a> /
+            <a class="side-link" href="https://www.lsst.org/">LSST</a> ·
+            <a class="side-link" href="https://www.euclid-ec.org/">Euclid</a>
           </p>
         </div>
         <div class="side-block">
@@ -102,11 +99,7 @@
         </div>
         <div class="side-block">
           <p class="side-key">Links</p>
-          <p class="side-val">
-            <a href="https://github.com/aboucaud" target="_blank" rel="noopener noreferrer">GitHub</a> ·
-            <a href="https://www.linkedin.com/in/aboucaud/" target="_blank" rel="noopener noreferrer">LinkedIn</a> ·
-            <a href="https://orcid.org/0000-0001-7387-2633" target="_blank" rel="noopener noreferrer">ORCID</a>
-          </p>
+          <p class="side-val" data-render="hero-links"></p>
         </div>
         <div class="side-block">
           <p class="side-key">Education</p>
@@ -200,8 +193,8 @@
           <h3 class="project-name">LSST / Rubin Observatory</h3>
           <p class="project-desc">Camera control software and commissioning for the Legacy Survey of Space and Time at Vera C. Rubin Observatory. On-site mission in Chile, Nov 2024 – Dec 2025.</p>
           <div class="project-links">
-            <a class="project-link" href="https://rubinobservatory.org/" target="_blank" rel="noopener noreferrer">Website</a>
-            <a class="project-link" href="https://www.youtube.com/watch?v=mFDl_llEca8" target="_blank" rel="noopener noreferrer">Observatory tour (in French)</a>
+            <a class="project-link" href="https://rubinobservatory.org/">Website</a>
+            <a class="project-link" href="https://www.youtube.com/watch?v=mFDl_llEca8">Observatory tour (in French)</a>
           </div>
         </article>
         <article class="project-card">
@@ -209,7 +202,7 @@
           <h3 class="project-name">Euclid</h3>
           <p class="project-desc">Deep learning methods for galaxy image analysis and weak lensing pipelines for ESA's Euclid dark energy mission. Science ground segment integration at IAS and APC.</p>
           <div class="project-links">
-            <a class="project-link" href="https://www.euclid-ec.org/" target="_blank" rel="noopener noreferrer">Website</a>
+            <a class="project-link" href="https://www.euclid-ec.org/">Website</a>
           </div>
         </article>
         <article class="project-card">
@@ -217,7 +210,7 @@
           <h3 class="project-name">AstroDeep</h3>
           <p class="project-desc">ANR-funded research programme applying deep learning to galaxy morphology, weak lensing, and image deblending for next-generation sky surveys (LSST, Euclid).</p>
           <div class="project-links">
-            <a class="project-link" href="https://astrodeep.net/" target="_blank" rel="noopener noreferrer">Website</a>
+            <a class="project-link" href="https://astrodeep.net/">Website</a>
           </div>
         </article>
         <article class="project-card">
@@ -225,8 +218,8 @@
           <h3 class="project-name">Lightcone Research</h3>
           <p class="project-desc">Open-source infrastructure for transparent and verifiable computational science assisted with agentic AI, all based on the ASTRA specification.</p>
           <div class="project-links">
-            <a class="project-link" href="https://lightconeresearch.org/" target="_blank" rel="noopener noreferrer">Website</a>
-            <a class="project-link" href="https://github.com/LightconeResearch" target="_blank" rel="noopener noreferrer">GitHub</a>
+            <a class="project-link" href="https://lightconeresearch.org/">Website</a>
+            <a class="project-link" href="https://github.com/LightconeResearch">GitHub</a>
           </div>
         </article>
       </div>
@@ -242,17 +235,17 @@
       <div class="talks-list" role="list">
         <div class="talk-row" role="listitem">
           <span class="talk-year">2023-24</span>
-          <span class="talk-title"><a href="https://aissai.cnrs.fr/evenement/ia-pour-les-deux-infinis/"  target="_blank" rel="noopener noreferrer">CNRS AISSAI interdisciplinary semester — (3 workshops, 1 hackathon, 1 winter school)</a></span>
+          <span class="talk-title"><a class="talk-link" href="https://aissai.cnrs.fr/evenement/ia-pour-les-deux-infinis/">CNRS AISSAI interdisciplinary semester — (3 workshops, 1 hackathon, 1 winter school)</a></span>
           <span class="talk-venue">Organizer</span>
         </div>
         <div class="talk-row" role="listitem">
           <span class="talk-year">2022-24</span>
-          <span class="talk-title">Machine learning introduction + MLOps — <a href="https://ede2026.sciencesconf.org/"  target="_blank" rel="noopener noreferrer">Rodolphe Clédassou (Euclid) Summer School</a></span>
+          <span class="talk-title">Machine learning introduction + MLOps — <a class="talk-link" href="https://ede2026.sciencesconf.org/">Rodolphe Clédassou (Euclid) Summer School</a></span>
           <span class="talk-venue">Lecturer</span>
         </div>
         <div class="talk-row" role="listitem">
           <span class="talk-year">2021-26</span>
-          <span class="talk-title"><a href="https://astroinfo2025.in2p3.fr/"  target="_blank" rel="noopener noreferrer">AstroInfo — CNRS thematic school + hackathon on scientific computing</a></span>
+          <span class="talk-title"><a class="talk-link" href="https://astroinfo2025.in2p3.fr/">AstroInfo — CNRS thematic school + hackathon on scientific computing</a></span>
           <span class="talk-venue">Organizer, Lecturer</span>
         </div>
         <div class="talk-row" role="listitem">
@@ -271,17 +264,17 @@
       <div class="talks-list" role="list">
         <div class="talk-row" role="listitem">
           <span class="talk-year">2023 – 2026</span>
-          <span class="talk-title"><a href="https://askabalan.github.io/" target="_blank" rel="noopener noreferrer">Wassim Kabalan</a><span class="talk-cosup">with Josquin Errard &amp; François Lanusse</span></span>
+          <span class="talk-title"><a class="talk-link" href="https://askabalan.github.io/">Wassim Kabalan</a><span class="talk-cosup">with Josquin Errard &amp; François Lanusse</span></span>
           <span class="talk-venue">APC, Paris</span>
         </div>
         <div class="talk-row" role="listitem">
           <span class="talk-year">2021 – 2024</span>
-          <span class="talk-title"><a href="https://justinezgh.github.io/" target="_blank" rel="noopener noreferrer">Justine Zeghal</a><span class="talk-cosup">with François Lanusse &amp; Eric Aubourg</span></span>
+          <span class="talk-title"><a class="talk-link" href="https://justinezgh.github.io/">Justine Zeghal</a><span class="talk-cosup">with François Lanusse &amp; Eric Aubourg</span></span>
           <span class="talk-venue">→ postdoc at Ciela Institute &amp; MILA, Montréal</span>
         </div>
         <div class="talk-row" role="listitem">
           <span class="talk-year">2019 – 2022</span>
-          <span class="talk-title"><a href="https://hbretonniere.github.io/" target="_blank" rel="noopener noreferrer">Hubert Bretonnière</a> <span class="talk-cosup">with Marc Huertas-Company</span></span>
+          <span class="talk-title"><a class="talk-link" href="https://hbretonniere.github.io/">Hubert Bretonnière</a> <span class="talk-cosup">with Marc Huertas-Company</span></span>
           <span class="talk-venue">→ ML engineer, Barcelona</span>
         </div>
       </div>
@@ -290,37 +283,17 @@
     <div class="contact-section" id="contact">
       <p class="contact-tagline">Get in touch</p>
       <div class="contact-rule" aria-hidden="true"></div>
-      <div class="contact-links">
-        <a class="contact-link-row" href="mailto:aboucaud@apc.in2p3.fr">
-          <span class="contact-link-label">Email</span>
-          <span class="contact-link-url">aboucaud@apc.in2p3.fr</span>
-        </a>
-        <!-- <a class="contact-link-row" href="https://bsky.app/profile/aboucaud.bsky.social">
-          <span class="contact-link-label">Bluesky</span>
-          <span class="contact-link-url">@aboucaud.bsky.social</span>
-        </a> -->
-        <a class="contact-link-row" href="https://github.com/aboucaud" target="_blank" rel="noopener noreferrer">
-          <span class="contact-link-label">GitHub</span>
-          <span class="contact-link-url">github.com/aboucaud</span>
-        </a>
-        <a class="contact-link-row" href="https://www.linkedin.com/in/aboucaud/" target="_blank" rel="noopener noreferrer">
-          <span class="contact-link-label">LinkedIn</span>
-          <span class="contact-link-url">linkedin.com/in/aboucaud</span>
-        </a>
-        <a class="contact-link-row" href="https://orcid.org/0000-0001-7387-2633" target="_blank" rel="noopener noreferrer">
-          <span class="contact-link-label">ORCID</span>
-          <span class="contact-link-url">0000-0001-7387-2633</span>
-        </a>
-      </div>
+      <div class="contact-links" data-render="contact-links"></div>
     </div>
 
     <footer>
-      <span class="footer-name">Alexandre Boucaud</span>
-      <span class="footer-copy">AstroParticule &amp; Cosmologie – CNRS – IN2P3</span>
+      <span class="footer-name" data-fill="name"></span>
+      <span class="footer-copy" data-fill="institution.footer"></span>
     </footer>
 
   </div>
 
+  <script src="js/data.js"></script>
   <script src="js/main.js"></script>
 </body>
 </html>

--- a/js/data.js
+++ b/js/data.js
@@ -1,0 +1,14 @@
+const SITE = {
+  name: 'Alexandre Boucaud',
+  email: 'aboucaud@apc.in2p3.fr',
+  institution: {
+    lab: { name: 'AstroParticule & Cosmologie', url: 'https://apc.u-paris.fr' },
+    cnrs: { name: 'CNRS/IN2P3', url: 'https://www.in2p3.cnrs.fr' },
+    footer: 'AstroParticule & Cosmologie – CNRS – IN2P3',
+  },
+  links: [
+    { label: 'GitHub', url: 'https://github.com/aboucaud', display: 'github.com/aboucaud' },
+    { label: 'LinkedIn', url: 'https://www.linkedin.com/in/aboucaud/', display: 'linkedin.com/in/aboucaud' },
+    { label: 'ORCID', url: 'https://orcid.org/0000-0001-7387-2633', display: '0000-0001-7387-2633' },
+  ],
+};

--- a/js/main.js
+++ b/js/main.js
@@ -1,3 +1,44 @@
+/* ── Config fill ─────────────────────────────────────────────────── */
+(function () {
+  if (typeof SITE === 'undefined') return;
+
+  document.querySelectorAll('[data-fill]').forEach(el => {
+    const val = el.dataset.fill.split('.').reduce((o, k) => o?.[k], SITE);
+    if (val != null) el.textContent = val;
+  });
+
+  const r = (sel, html) => { const el = document.querySelector(sel); if (el) el.innerHTML = html; };
+
+  r('[data-render="institution"]',
+    `<a class="side-link" href="${SITE.institution.lab.url}">${SITE.institution.lab.name}</a> · ` +
+    `<a class="side-link" href="${SITE.institution.cnrs.url}">${SITE.institution.cnrs.name}</a>`
+  );
+
+  r('[data-render="hero-links"]',
+    SITE.links.map(l =>
+      `<a class="side-link" href="${l.url}">${l.label}</a>`
+    ).join(' · ')
+  );
+
+  r('[data-render="contact-links"]',
+    `<a class="contact-link-row" href="mailto:${SITE.email}">` +
+      `<span class="contact-link-label">Email</span>` +
+      `<span class="contact-link-url">${SITE.email}</span>` +
+    `</a>` +
+    SITE.links.map(l =>
+      `<a class="contact-link-row side-link" href="${l.url}">` +
+        `<span class="contact-link-label">${l.label}</span>` +
+        `<span class="contact-link-url">${l.display}</span>` +
+      `</a>`
+    ).join('')
+  );
+
+  document.querySelectorAll('.project-link, .side-link, .talk-link').forEach(a => {
+    a.target = '_blank';
+    a.rel = 'noopener noreferrer';
+  });
+}());
+
 /* ── Photo carousel ───────────────────────────────────────────────── */
 (function () {
   const slides = document.querySelectorAll('.carousel-slide');
@@ -11,13 +52,13 @@
   function goTo(n) {
     if (transitioning) return;
     transitioning = true;
-    setTimeout(() => { transitioning = false; }, 1000);
 
-    slides[current].style.zIndex = '1';
-    slides[current].classList.remove('active');
-    if (dots[current]) {
-      dots[current].classList.remove('active');
-      dots[current].setAttribute('aria-selected', 'false');
+    const prev = current;
+    slides[prev].style.zIndex = '1';
+    slides[prev].classList.remove('active');
+    if (dots[prev]) {
+      dots[prev].classList.remove('active');
+      dots[prev].setAttribute('aria-selected', 'false');
     }
 
     current = (n + slides.length) % slides.length;
@@ -29,7 +70,11 @@
       dots[current].setAttribute('aria-selected', 'true');
     }
 
-    setTimeout(() => { slides[current].style.zIndex = ''; }, 1000);
+    setTimeout(() => {
+      slides[prev].style.zIndex = '';
+      slides[current].style.zIndex = '';
+      transitioning = false;
+    }, 1000);
   }
 
   function startTimer() { timer = setInterval(() => goTo(current + 1), 5000); }


### PR DESCRIPTION
## Summary

- **`js/data.js`** (new): single source of truth for name, email, institution, and social links — repeated values across nav/hero/footer/contact are rendered from this file at page load
- **`index.html`**: replace repeated personal info with `data-fill`/`data-render` sentinel attributes; external links get semantic classes (`side-link`, `project-link`, `talk-link`) instead of inline `target`/`rel`
- **`js/main.js`**: config-fill IIFE renders `data.js` into the page and applies `target="_blank" rel="noopener noreferrer"` to all classified links in one pass after renders; fix carousel `goTo()` bug where outgoing slide retained inline z-index, blocking button clicks after the first transition
- **`css/resume.css`**: add `z-index: 3` to `.carousel-btn` as belt-and-suspenders
- **`CLAUDE.md`**: document `data.js` config, link class convention, and what each `SITE.*` key drives

## Test plan

- [ ] Name appears correctly in nav, hero `<h1>`, and footer
- [ ] Institution links render in hero sidebar
- [ ] Social links render in hero sidebar and contact section
- [ ] All `.project-link`, `.side-link`, `.talk-link` anchors open in a new tab
- [ ] Carousel prev/next buttons work after multiple clicks (z-index fix)
- [ ] Carousel auto-advances normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)